### PR TITLE
Added RDS DB Parameter Group and assigned it to RDS instance

### DIFF
--- a/aws/rds.tf
+++ b/aws/rds.tf
@@ -58,11 +58,23 @@ resource "aws_db_subnet_group" "rds" {
   })
 }
 
+#RDS DB Parameter Group
+resource "aws_db_parameter_group" "mysqlpg" {
+  name   = "${var.project_name}-${var.environment}-rds-parameter-group"
+  family = "mysql8.0"
+
+  parameter {
+    name  = "max_connect_errors"
+    value = "10000"
+  }
+}
+
 # RDS MySQL Instance
 resource "aws_db_instance" "mysql" {
   identifier     = "${var.project_name}-${var.environment}-mysql"
   engine         = "mysql"
   engine_version = "8.0"
+  parameter_group_name = aws_db_parameter_group.mysqlpg.name
   instance_class = var.rds_instance_class
   
   allocated_storage     = var.rds_allocated_storage


### PR DESCRIPTION
Added a few lines to rds.tf to create a database parameter group with the "max_connect_errors" parameter set to "10000".
This PR closes the issue ["Many connection errors" for RDS Database](https://github.com/haleyyyblue/databricks-ncc-demo/issues/4).
Below are screenshots after deployment:
<img width="398" height="805" alt="image" src="https://github.com/user-attachments/assets/09540942-8043-4d5f-bb50-1a5345465d9f" />
<img width="1592" height="352" alt="image" src="https://github.com/user-attachments/assets/2eba81e4-e5fd-4f9f-af09-3a11ab6fa3a6" />
