### PR TITLE
Added variable for endpoint auto-approval

### DIFF
--- a/aws/nlb.tf
+++ b/aws/nlb.tf
@@ -140,7 +140,7 @@ resource "aws_vpc_endpoint_service" "mysql_privatelink" {
   count = var.enable_mysql_proxy && var.enable_nlb && var.enable_endpoint_service ? 1 : 0
 
   network_load_balancer_arns   = [aws_lb.mysql_nlb[0].arn]
-  acceptance_required          = true    # Require acceptance for endpoint connections
+  acceptance_required          = var.endpoint_acceptance_required
   supported_ip_address_types   = ["ipv4"] # IPv4 support only
   
   depends_on = [

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -95,6 +95,7 @@
   # VPC Endpoint Service Configuration (PrivateLink)
   enable_endpoint_service = true  # Enable for cross-account/cross-VPC private access
   endpoint_service_allowed_principal = "arn:aws:iam::565502421330:role/private-connectivity-role-us-west-2"  # Replace account ID as needed
+  endpoint_acceptance_required = false # Setting this to "true" means the private endpoint service must be manually approved in the endpoint service
 
 # -----------------------------------------------------------------------------
 # NCC Configuration

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -208,6 +208,12 @@ variable "endpoint_service_allowed_principal" {
   }
 }
 
+variable "endpoint_acceptance_required" {
+  description = "Specify whether EP must be manually approved for allowed principal"
+  type        = bool
+  default     = false
+}
+
 variable "assign_public_ip_to_ec2" {
   description = "EC2 subnet placement: true = public subnet + public IP, false = private subnet + no public IP"
   type        = bool


### PR DESCRIPTION
I've included a variable that allows the NCC serverless endpoint to be auto-approved upon creation. Changes include adding the variable to variables.tf, including an example variable in terraform.tfvars.example and changing the acceptance_required parameter in nlb.tf to use the variable value rather than hardcoding it to false. 